### PR TITLE
Added form to login and ProgressSpinner

### DIFF
--- a/src/api/statistics.js
+++ b/src/api/statistics.js
@@ -15,7 +15,7 @@ const statistics = {
     getters: {
       get_cluster_request_info (state) { return state.cluster_request_info },
       get_cluster_info (state) { return state.cluster_info },
-      get_is_loaded (state) { return state.is_loaded } 
+      get_is_loaded (state) { return state.is_loaded }
     },
 
     mutations: {
@@ -25,7 +25,7 @@ const statistics = {
     },
 
     actions: {
-      async get_cluster_infos (context, infos) {
+      async request_cluster_infos (context, infos) {
         const newClusterInfo = []
         for (const field of infos) {
           const info = await backend.read(`/cluster/${field}/`)

--- a/src/api/statistics.js
+++ b/src/api/statistics.js
@@ -8,17 +8,20 @@ const statistics = {
       cluster_request_info: [
         'portal_user_count', 'portal_version', 'k8s_version', 'k8s_node_count', 'k8s_cpu_count',
         'k8s_mem_sum', 'k8s_pod_count', 'k8s_volume_count', 'k8s_apiserver_url', 'k8s_cluster_name'],
-      cluster_info: []
+      cluster_info: [],
+      is_loaded: false
     },
 
     getters: {
       get_cluster_request_info (state) { return state.cluster_request_info },
-      get_cluster_info (state) { return state.cluster_info }
+      get_cluster_info (state) { return state.cluster_info },
+      get_is_loaded (state) { return state.is_loaded } 
     },
 
     mutations: {
       update_cluster_info (state, info) { state.cluster_info.push(info) },
-      set_cluster_info (state, info) { state.cluster_info = info }
+      set_cluster_info (state, info) { state.cluster_info = info },
+      set_is_loaded (state, info) { state.is_loaded = info }
     },
 
     actions: {
@@ -29,6 +32,7 @@ const statistics = {
           newClusterInfo.push(info.data)
         }
         context.commit('set_cluster_info', newClusterInfo)
+        context.commit('set_is_loaded', true)
       }
     }
   }

--- a/src/api/statistics.js
+++ b/src/api/statistics.js
@@ -9,19 +9,16 @@ const statistics = {
         'portal_user_count', 'portal_version', 'k8s_version', 'k8s_node_count', 'k8s_cpu_count',
         'k8s_mem_sum', 'k8s_pod_count', 'k8s_volume_count', 'k8s_apiserver_url', 'k8s_cluster_name'],
       cluster_info: [],
-      is_loaded: false
     },
 
     getters: {
       get_cluster_request_info (state) { return state.cluster_request_info },
-      get_cluster_info (state) { return state.cluster_info },
-      get_is_loaded (state) { return state.is_loaded }
+      get_cluster_info (state) { return state.cluster_info }
     },
 
     mutations: {
       update_cluster_info (state, info) { state.cluster_info.push(info) },
       set_cluster_info (state, info) { state.cluster_info = info },
-      set_is_loaded (state, info) { state.is_loaded = info }
     },
 
     actions: {
@@ -32,7 +29,6 @@ const statistics = {
           newClusterInfo.push(info.data)
         }
         context.commit('set_cluster_info', newClusterInfo)
-        context.commit('set_is_loaded', true)
       }
     }
   }

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -12,7 +12,8 @@ const users_container = {
       is_authenticated: '',
       user_details: {},
       user_webapps: [],
-      user_groups: []
+      user_groups: [],
+      webapps_loaded: false
     },
 
     getters: {
@@ -21,7 +22,8 @@ const users_container = {
       get_user_firstname (state) { return state.user_firstname },
       get_user_webapps (state) { return state.user_webapps },
       get_is_authenticated (state) { return state.is_authenticated },
-      get_user_groups (state) { return state.user_groups }
+      get_user_groups (state) { return state.user_groups },
+      get_webapps_loaded (state) { return state.webapps_loaded }
     },
 
     mutations: {
@@ -29,7 +31,8 @@ const users_container = {
       set_user_firstname (state, name) { state.user_firstname = name },
       set_user_details (state, user_details) { state.user_details = user_details },
       set_user_webapps (state, webapps) { state.user_webapps = webapps },
-      set_is_authenticated (state, is_authenticated) { state.is_authenticated = is_authenticated }
+      set_is_authenticated (state, is_authenticated) { state.is_authenticated = is_authenticated },
+      set_webapps_loaded (state, loaded) { state.webapps_loaded = loaded }
     },
 
     actions: {
@@ -40,9 +43,11 @@ const users_container = {
       },
       async post_login_data (context, request_body) {
         const response = await backend.create('/login/', request_body)
-        context.commit('set_user_id', response.data['id'])
-        context.commit('set_user_firstname', response.data['firstname'])
-        store.commit('api/set_access_token', response.data['access_token'])
+        if (response) {
+          context.commit('set_user_id', response.data['id'])
+          context.commit('set_user_firstname', response.data['firstname'])
+          store.commit('api/set_access_token', response.data['access_token'])
+        }
         return response
       },
       async authorize_google_user (context, auth_response) {
@@ -50,8 +55,9 @@ const users_container = {
         // @ TODO
         return response
       },
-      async get_user_webapps (context) {
+      async request_user_webapps (context) {
         const response = await backend.read(`/users/${context.state.user_id}/webapps/`)
+        context.commit('set_webapps_loaded', true)
         response !== undefined ? context.commit('set_user_webapps', response.data) : console.log('no webapps found')
         return response
       },

--- a/src/api/users.js
+++ b/src/api/users.js
@@ -12,8 +12,7 @@ const users_container = {
       is_authenticated: '',
       user_details: {},
       user_webapps: [],
-      user_groups: [],
-      webapps_loaded: false
+      user_groups: []
     },
 
     getters: {
@@ -22,8 +21,7 @@ const users_container = {
       get_user_firstname (state) { return state.user_firstname },
       get_user_webapps (state) { return state.user_webapps },
       get_is_authenticated (state) { return state.is_authenticated },
-      get_user_groups (state) { return state.user_groups },
-      get_webapps_loaded (state) { return state.webapps_loaded }
+      get_user_groups (state) { return state.user_groups }
     },
 
     mutations: {
@@ -31,8 +29,7 @@ const users_container = {
       set_user_firstname (state, name) { state.user_firstname = name },
       set_user_details (state, user_details) { state.user_details = user_details },
       set_user_webapps (state, webapps) { state.user_webapps = webapps },
-      set_is_authenticated (state, is_authenticated) { state.is_authenticated = is_authenticated },
-      set_webapps_loaded (state, loaded) { state.webapps_loaded = loaded }
+      set_is_authenticated (state, is_authenticated) { state.is_authenticated = is_authenticated }
     },
 
     actions: {
@@ -57,7 +54,6 @@ const users_container = {
       },
       async request_user_webapps (context) {
         const response = await backend.read(`/users/${context.state.user_id}/webapps/`)
-        context.commit('set_webapps_loaded', true)
         response !== undefined ? context.commit('set_user_webapps', response.data) : console.log('no webapps found')
         return response
       },

--- a/src/components/Profile/Profile.vue
+++ b/src/components/Profile/Profile.vue
@@ -20,7 +20,7 @@
           </b-card-body>
         </b-card>
       </div>
-        <div class="col-lg-7">
+        <div class="col-lg-8">
           <KubeInstallation class="installation" />
         </div>
     </div>

--- a/src/components/RequestSpinner.vue
+++ b/src/components/RequestSpinner.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="text-center m-4">
+        <v-progress-circular
+        :size="50"
+        color="primary"
+        indeterminate
+      ></v-progress-circular>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'RequestSpinner'
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/WebAppContainer.vue
+++ b/src/components/WebAppContainer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <RequestSpinner v-if="!loaded"/>
+    <RequestSpinner v-if="webapps.length === 0"/>
     <div class="my-4 container-sm" v-else>
       <b-button v-for="app in webapps" :key="app.index" class="app-button">
         {{ app.link_name }}
@@ -16,9 +16,6 @@ export default {
   name: 'WebAppContainer',
   components: { RequestSpinner },
   computed: {
-    loaded () {
-      return this.$store.getters['users/get_webapps_loaded']
-    },
     webapps () {
       return this.$store.getters['users/get_user_webapps']
     }

--- a/src/components/WebAppContainer.vue
+++ b/src/components/WebAppContainer.vue
@@ -1,12 +1,6 @@
 <template>
   <div>
-    <div class="text-center" v-if="!loaded">
-        <v-progress-circular
-        :size="50"
-        color="primary"
-        indeterminate
-      ></v-progress-circular>
-    </div>
+    <RequestSpinner v-if="!loaded"/>
     <div class="my-4 container-sm" v-else>
       <b-button v-for="app in webapps" :key="app.index" class="app-button">
         {{ app.link_name }}
@@ -16,26 +10,18 @@
 </template>
 
 <script>
+import RequestSpinner from './RequestSpinner'
+
 export default {
   name: 'WebAppContainer',
-  data(){
-    return{
-      loaded: false,
-      webapps: []
+  components: { RequestSpinner },
+  computed: {
+    loaded () {
+      return this.$store.getters['users/get_webapps_loaded']
+    },
+    webapps () {
+      return this.$store.getters['users/get_user_webapps']
     }
-  },
-  methods: {
-    get_webapps: function () {
-      this.webapps = this.$store.getters['users/get_user_webapps']
-      this.loaded = true
-    }
-  },
-  created () {
-    
-  },
-  mounted () {
-    this.$store.dispatch('users/get_user_webapps')
-    this.get_webapps()
   }
 }
 </script>

--- a/src/components/WebAppContainer.vue
+++ b/src/components/WebAppContainer.vue
@@ -1,21 +1,41 @@
 <template>
-  <div class="my-4 container-sm ">
-    <b-button v-for="app in webapps" :key="app.index" class="app-button">
-      {{ app.link_name }}
-    </b-button>
+  <div>
+    <div class="text-center" v-if="!loaded">
+        <v-progress-circular
+        :size="50"
+        color="primary"
+        indeterminate
+      ></v-progress-circular>
+    </div>
+    <div class="my-4 container-sm" v-else>
+      <b-button v-for="app in webapps" :key="app.index" class="app-button">
+        {{ app.link_name }}
+      </b-button>
+    </div>
   </div>
 </template>
 
 <script>
 export default {
   name: 'WebAppContainer',
-  computed: {
-    webapps () {
-      return this.$store.getters['users/get_user_webapps']
+  data(){
+    return{
+      loaded: false,
+      webapps: []
     }
   },
-  async created () {
-    await this.$store.dispatch('users/get_user_webapps')
+  methods: {
+    get_webapps: function () {
+      this.webapps = this.$store.getters['users/get_user_webapps']
+      this.loaded = true
+    }
+  },
+  created () {
+    
+  },
+  mounted () {
+    this.$store.dispatch('users/get_user_webapps')
+    this.get_webapps()
   }
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,7 @@ const gauthOption = {
 
 const vuexLocalStorage = new VuexPersistence({
   key: 'vuex', // The key to store the state on in the storage provider.
-  storage: window.localStorage,
+  storage: window.localStorage
   // reducer: (state) => ({user: state.user}) // or window.sessionStorage or localForage
   // Function that passes the state and returns the state with only the objects you want to store.
 }).plugin(store)

--- a/src/main.js
+++ b/src/main.js
@@ -17,7 +17,8 @@ const gauthOption = {
 
 const vuexLocalStorage = new VuexPersistence({
   key: 'vuex', // The key to store the state on in the storage provider.
-  storage: window.localStorage // or window.sessionStorage or localForage
+  storage: window.localStorage,
+  // reducer: (state) => ({user: state.user}) // or window.sessionStorage or localForage
   // Function that passes the state and returns the state with only the objects you want to store.
 }).plugin(store)
 

--- a/src/views/Kubeportal.vue
+++ b/src/views/Kubeportal.vue
@@ -102,12 +102,6 @@ export default {
     }
   },
   methods: {
-    get_all_statistic_values () {
-      this.statistics.map(this.request_cluster_info)
-    },
-    async request_cluster_info (cluster_info) {
-      await this.$store.dispatch('statistics/get_cluster_info', cluster_info)
-    },
     logout () {
       this.$store.commit('users/set_user_id', null)
       this.$store.commit('users/set_user_firstname', '')

--- a/src/views/Kubeportal.vue
+++ b/src/views/Kubeportal.vue
@@ -109,7 +109,6 @@ export default {
       this.$store.commit('users/set_user_details', {})
       this.$store.commit('users/set_user_webapps', [])
       this.$store.commit('statistics/set_cluster_info', [])
-      this.$store.commit('statistics/set_is_loaded', false)
       this.$store.commit('api/set_csrf_token', '')
       this.$store.commit('api/set_access_token', '')
 

--- a/src/views/Kubeportal.vue
+++ b/src/views/Kubeportal.vue
@@ -115,6 +115,7 @@ export default {
       this.$store.commit('users/set_user_details', {})
       this.$store.commit('users/set_user_webapps', [])
       this.$store.commit('statistics/set_cluster_info', [])
+      this.$store.commit('statistics/set_is_loaded', false)
       this.$store.commit('api/set_csrf_token', '')
       this.$store.commit('api/set_access_token', '')
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,26 +1,28 @@
 <template>
     <b-card bg-variant="light" class="mt-16 logincard">
-      <b-card-header>
-        <v-icon class="icon" left>mdi-login-variant</v-icon>
-        Kubeportal
-      </b-card-header>
-      <b-card-body>
-        <v-alert class="alert" dense outlined type="error" v-if="is_authenticated === 'false'">Login Failed.</v-alert>
-        <b-card-text>
-          <v-text-field label="user name" v-model="username" required></v-text-field>
-          <v-text-field type="password" v-model="password" label="password" required></v-text-field>
-        </b-card-text>
-        <div class="row">
-          <b-button class="signin" @click="login">Sign In</b-button>
-        </div>
-        <div class="row"><p class="my-4 text">or</p></div>
-        <div class="row">
-          <b-button class="signin" @click="signInWithGoogle">
-            <v-icon  white small left>mdi-google</v-icon>
-            Continue with Google
-          </b-button>
-        </div>
-      </b-card-body>
+      <b-form @submit.prevent="login">
+        <b-card-header>
+          <v-icon class="icon" left>mdi-login-variant</v-icon>
+          Kubeportal
+        </b-card-header>
+        <b-card-body>
+          <v-alert class="alert" dense outlined type="error" v-if="is_authenticated === 'false'">Login Failed.</v-alert>
+          <b-card-text>
+            <v-text-field label="user name" v-model="username" required></v-text-field>
+            <v-text-field type="password" v-model="password" label="password" required></v-text-field>
+          </b-card-text>
+          <div class="row">
+            <b-button type="submit" class="signin">Sign In</b-button>
+          </div>
+          <div class="row"><p class="my-4 text">or</p></div>
+          <div class="row">
+            <b-button class="signin" @click="signInWithGoogle">
+              <v-icon  white small left>mdi-google</v-icon>
+              Continue with Google
+            </b-button>
+          </div>
+        </b-card-body>
+      </b-form>
     </b-card>
 </template>
 
@@ -41,7 +43,7 @@ export default {
     async login () {
       const request_body = { username: this.username, password: this.password }
       const response = await this.$store.dispatch('users/post_login_data', request_body)
-      console.log(response);
+      console.log(response)
 
       await this.handle_login_response(response)
     },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -5,7 +5,10 @@
           <v-icon class="icon" left>mdi-login-variant</v-icon>
           Kubeportal
         </b-card-header>
-        <b-card-body>
+        <b-card-body v-if="loading">
+          <RequestSpinner />
+        </b-card-body>
+        <b-card-body v-else>
           <v-alert class="alert" dense outlined type="error" v-if="is_authenticated === 'false'">Login Failed.</v-alert>
           <b-card-text>
             <v-text-field label="user name" v-model="username" required></v-text-field>
@@ -29,18 +32,22 @@
 <script>
 import to from 'await-to-js'
 import * as backend from '@/api/backend'
+import RequestSpinner from '../components/RequestSpinner'
 export default {
   name: 'Login',
+  components: { RequestSpinner },
   data () {
     return {
       is_authenticated: '',
       username: '',
       password: '',
-      isSignedIn: ''
+      isSignedIn: '',
+      loading: false
     }
   },
   methods: {
     async login () {
+      this.loading = true
       const request_body = { username: this.username, password: this.password }
       const response = await this.$store.dispatch('users/post_login_data', request_body)
       console.log(response)
@@ -64,14 +71,14 @@ export default {
     async handle_login_response (response) {
       console.log(response)
       if(response === undefined) {
+        this.loading = false
         this.is_authenticated = 'false'
-        await this.$router.push({ name: 'Home' })
+        // await this.$router.push({ name: 'Home' })
       } else if (response.status === 200) {
         this.$store.commit('users/set_is_authenticated', 'true')
         this.$store.dispatch('users/get_user_details', response.data['id'])
         this.$store.dispatch('users/get_user_groups')
         this.$router.push({ name: 'Kubeportal' })
-        
       }
     }
   },

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -68,9 +68,10 @@ export default {
         await this.$router.push({ name: 'Home' })
       } else if (response.status === 200) {
         this.$store.commit('users/set_is_authenticated', 'true')
-        await this.$store.dispatch('users/get_user_details', response.data['id'])
-        await this.$store.dispatch('users/get_user_groups')
-        await this.$router.push({ name: 'Kubeportal' })
+        this.$store.dispatch('users/get_user_details', response.data['id'])
+        this.$store.dispatch('users/get_user_groups')
+        this.$router.push({ name: 'Kubeportal' })
+        
       }
     }
   },

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -1,18 +1,9 @@
 <template>
   <b-card class="maincard">
     <b-card-header>
-      <v-row>
-        <v-col cols="11"> Cluster Statistics </v-col>
-        <v-col cols="1">
-          <v-btn icon
-          color="primary"
-          @click="request_cluster_infos">
-            <v-icon>mdi-cached</v-icon>
-          </v-btn>
-        </v-col>
-      </v-row>
+      Cluster Statistics
     </b-card-header>
-    <RequestSpinner v-if="!is_loaded" />
+    <RequestSpinner v-if="all_statistics.length === 0" />
     <div v-else>
       <v-simple-table fixed-header>
         <template v-slot:default>
@@ -40,9 +31,6 @@ export default {
   name: 'Statistics',
   components: { RequestSpinner },
   computed: {
-    is_loaded () {
-      return this.$store.getters['statistics/get_is_loaded']
-    },
     all_statistics () {
       return this.$store.getters['statistics/get_cluster_info']
     }
@@ -50,7 +38,6 @@ export default {
   methods: {
     request_cluster_infos () {
       let cluster_infos = this.$store.getters['statistics/get_cluster_request_info']
-      this.$store.commit('statistics/set_is_loaded', false)
       this.$store.dispatch('statistics/request_cluster_infos', cluster_infos)
     }
   }

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -1,40 +1,44 @@
 <template>
   <b-card class="maincard">
     <b-card-header>
-      Cluster Statistics
+      <v-row>
+        <v-col cols="11"> Cluster Statistics </v-col>
+        <v-col cols="1">
+          <v-btn icon
+          color="primary"
+          @click="request_cluster_infos">
+            <v-icon>mdi-cached</v-icon>
+          </v-btn>
+        </v-col>
+      </v-row>
     </b-card-header>
-    <div class="text-center" v-if="!is_loaded">
-            <v-progress-circular
-            :size="50"
-            color="primary"
-            indeterminate
-          ></v-progress-circular>
-        </div>
+    <RequestSpinner v-if="!is_loaded" />
     <div v-else>
-    <v-simple-table fixed-header>
-      <template v-slot:default>
-        <thead>
-        <tr>
-          <th class="first text-left">Name</th>
-          <th class="second text-left">Value</th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr v-for="item in all_statistics" :key="item.index">
-          <td>{{ Object.keys(item)[0] }}</td>
-          <td>{{ Object.values(item)[0] }}</td>
-        </tr>
-        </tbody>
-      </template>
-    </v-simple-table>
+      <v-simple-table fixed-header>
+        <template v-slot:default>
+          <thead>
+            <tr>
+              <th class="first text-left">Name</th>
+              <th class="second text-left">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in all_statistics" :key="item.index">
+              <td>{{ Object.keys(item)[0] }}</td>
+              <td>{{ Object.values(item)[0] }}</td>
+            </tr>
+          </tbody>
+        </template>
+      </v-simple-table>
     </div>
   </b-card>
 </template>
 
 <script>
-
+import RequestSpinner from '../components/RequestSpinner'
 export default {
   name: 'Statistics',
+  components: { RequestSpinner },
   computed: {
     is_loaded () {
       return this.$store.getters['statistics/get_is_loaded']
@@ -42,21 +46,22 @@ export default {
     all_statistics () {
       return this.$store.getters['statistics/get_cluster_info']
     }
-  }/*,
-  created () {
-    console.log(this.is_loaded)
   },
-  mounted () {
-    console.log(this.is_loaded)
-  }*/
+  methods: {
+    request_cluster_infos () {
+      let cluster_infos = this.$store.getters['statistics/get_cluster_request_info']
+      this.$store.commit('statistics/set_is_loaded', false)
+      this.$store.dispatch('statistics/request_cluster_infos', cluster_infos)
+    }
+  }
 }
 </script>
 
 <style scoped lang="scss">
-  .first {
-    width: 30rem;
-  }
-  .wrapper {
-    height: 70vh !important;
-  }
+.first {
+  width: 30rem;
+}
+.wrapper {
+  height: 70vh !important;
+}
 </style>

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -3,7 +3,14 @@
     <b-card-header>
       Cluster Statistics
     </b-card-header>
-    <div>
+    <div class="text-center" v-if="!is_loaded">
+            <v-progress-circular
+            :size="50"
+            color="primary"
+            indeterminate
+          ></v-progress-circular>
+        </div>
+    <div v-else>
     <v-simple-table fixed-header>
       <template v-slot:default>
         <thead>
@@ -29,10 +36,19 @@
 export default {
   name: 'Statistics',
   computed: {
+    is_loaded () {
+      return this.$store.getters['statistics/get_is_loaded']
+    },
     all_statistics () {
       return this.$store.getters['statistics/get_cluster_info']
     }
-  }
+  }/*,
+  created () {
+    console.log(this.is_loaded)
+  },
+  mounted () {
+    console.log(this.is_loaded)
+  }*/
 }
 </script>
 

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -3,7 +3,6 @@
         <b-card-header>
           Hello: {{ this.current_user_firstname }} !
         </b-card-header>
-        
         <WebAppContainer />
       </b-card>
 </template>
@@ -20,17 +19,25 @@ export default {
     }
   },
   methods: {
-    get_cluster_infos () {
-      let cluster_request = this.$store.getters['statistics/get_cluster_request_info']
-      this.request_infos(cluster_request)
-      //cluster_request.map(info => this.request_infos(info))
+
+    async request_cluster_infos () {
+      let cluster_info = this.$store.getters['statistics/get_cluster_info']
+      if(cluster_info.length === 0) {
+        let cluster_infos = this.$store.getters['statistics/get_cluster_request_info']
+        this.$store.dispatch('statistics/request_cluster_infos', cluster_infos)
+      }
     },
-    async request_infos (infos) {
-      await this.$store.dispatch('statistics/get_cluster_infos', infos)
+    async request_webapps () {
+      let apps = this.$store.getters['users/get_user_webapps']
+
+      if (apps.length === 0) {
+        this.$store.dispatch('users/request_user_webapps')
+      }
     }
   },
-  created () {
-    this.get_cluster_infos()
+  mounted () {
+    this.request_cluster_infos()
+    this.request_webapps()
   }
 }
 </script>

--- a/src/views/Welcome.vue
+++ b/src/views/Welcome.vue
@@ -1,8 +1,9 @@
 <template>
       <b-card bg-variant="light" class="maincard">
-          <b-card-header>
-            Hello: {{ this.current_user_firstname }} !
-          </b-card-header>
+        <b-card-header>
+          Hello: {{ this.current_user_firstname }} !
+        </b-card-header>
+        
         <WebAppContainer />
       </b-card>
 </template>


### PR DESCRIPTION
I've added a form to the Login, so its possible to just submit a request, without having to click a button.

I have also added a RequestSpinner component, currently deposited in components, without a corresponding folder.

When you submit a login request a RequestSpinner is now displayed, if a request was invalid, the form appears again.
I have also fixed a small bug.
If an invalid request were to be made, it would try to read data from undefined.

In Welcome.vue two requests are made, after its mounted.
- a request for the WebAppContainer to preload each container
- a request for the Statistics to preload all incoming statistics

I have added an attribute for the WebApps, in users.js called webapps_loaded and one in statistics.js called is_loaded,
both are used to update the life-cycle-hook in Vue.
In Statistics.vue and WebAppContainer.vue while the request is ongoing a RequestSpinner is displayed.

Vuex saves each store in the localStorage, so even if you reload the data will still be accessible, but in the older version, if we were to reload the page, a new request would be made and the data in each store would be overwritten.
I have changed that, so a request is only made once.

Now if you wanted to refresh the statistics, a reload would no longer be possible since no new request would be made.
You would have to sign out and log back in to get the refreshed statistics.
To solve that problem I added a small button on the right side of the card-header.
![Screenshot from 2020-11-10 13-42-39](https://user-images.githubusercontent.com/58952375/98675492-a1972c80-235a-11eb-8c33-96600b961b1e.png)

Some of the formatting is currently off, for example the card-header in Statistics.vue is larger than the card-header in Welcome.vue.
But after this PR, I will start working on the switch from bootstrap to vuetify and look more into this issue.
