### PR TITLE
Cluster access

### DIFF
--- a/src/components/RequestAccess/RequestAccess.vue
+++ b/src/components/RequestAccess/RequestAccess.vue
@@ -37,6 +37,9 @@ export default {
   computed: {
     supervisors () {
       return this.get_supervisors()
+    },
+    current_user () {
+      return this.$store.getters['users/get_user']
     }
   },
   methods: {
@@ -50,6 +53,9 @@ export default {
         console.log(this.selected)
       }
     }
+  },
+  mounted () {
+    this.$store.dispatch('users/request_user')
   }
 }
 </script>

--- a/src/components/RequestAccess/RequestAccess.vue
+++ b/src/components/RequestAccess/RequestAccess.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
       <v-subheader>
-        You can send an access request to an administrator of your choice:
+        {{display_message()}}
       </v-subheader>
       <v-card class="my-4">
           <v-card-title>
@@ -31,10 +31,15 @@ export default {
   components: { TopBar, RequestSpinner },
   data () {
     return {
-      selected: []
+      selected: [],
+      NEW: 'not requested',
+      ACCESS_REQUESTED: 'requested',
+      ACCESS_REJECTED: 'rejected',
+      ACCESS_APPROVED: 'approved'
     }
   },
   computed: {
+
     supervisors () {
       return this.get_supervisors()
     },
@@ -43,6 +48,13 @@ export default {
     }
   },
   methods: {
+    display_message () {
+      switch (this.current_user['state']) {
+        case this.NEW: return 'You can send an access request to an administrator of your choice:'
+        case this.ACCESS_REQUESTED: return 'Your request for cluster access was already sent to the administrators.\nIf needed, you can re-send an access request to an administrator of your choice:'
+        case this.ACCESS_REJECTED: return 'Sorry, you have no access to the cluster.'
+      }
+    },
     get_supervisors () {
       //TODO: read api
       return ['troeger', 'sachs', 'xyz']

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -95,6 +95,10 @@ const users_container = {
         store.commit('pods/set_pod_links', response.data['pods'])
         store.commit('deployments/set_deployment_links', response.data['deployments'])
       },
+      async request_user (context) {
+        const response = await backend.get(context.state.url)
+        context.commit('set_user', response.data)
+      },
       async update_user (context, payload) {
         const response = await backend.patch(context.state.url, payload)
         context.commit('set_user', response.data)

--- a/src/views/Kubeportal.vue
+++ b/src/views/Kubeportal.vue
@@ -17,41 +17,49 @@ export default {
   name: 'App',
 
   components: { Welcome, Container, Storage, Network, RequestAccess, Wizard, Dashboard },
+  data () {
+    return {
+      NEW: 'not requested',
+      ACCESS_REQUESTED: 'requested',
+      ACCESS_REJECTED: 'rejected',
+      ACCESS_APPROVED: 'approved'
+    }
+  },
   computed: {
-    has_access () {
-      return true
+    user_state () {
+      return this.$store.getters['users/get_user']['state']
     },
     tabs () {
       return [
         {
           icon: 'mdi-home-heart',
           name: 'Welcome',
-          has_access: this.has_access,
+          has_access: true,
           component: Welcome
         }, {
           icon: 'mdi-key',
           name: 'Request Access',
-          has_access: !this.has_access,
+          has_access: this.user_state !== this.ACCESS_APPROVED,
           component: RequestAccess
         }, {
           icon: 'mdi-package',
           name: 'Container',
-          has_access: this.has_access,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: Container
         }, {
           icon: 'mdi-database',
           name: 'Storage',
-          has_access: this.has_access,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: Storage
         }, {
           icon: 'mdi-lan',
           name: 'Network',
-          has_access: this.has_access,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: Network
         }, {
           icon: 'mdi-wizard-hat',
           name: 'Wizard',
-          has_access: this.has_access,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: Wizard
         }
       ]

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -13,7 +13,19 @@ import Profile from '@/components/Settings/Profile/Profile'
 export default {
   name: 'Settings',
   components: { Dashboard },
+  data () {
+    return {
+      NEW: 'not requested',
+      ACCESS_REQUESTED: 'requested',
+      ACCESS_REJECTED: 'rejected',
+      ACCESS_APPROVED: 'approved'
+    }
+  },
+
   computed: {
+    user_state () {
+      return this.$store.getters['users/get_user']['state']
+    },
     tabs () {
       return [
         {
@@ -24,12 +36,12 @@ export default {
         }, {
           icon: 'mdi-kubernetes',
           name: 'Kubernetes',
-          has_access: true,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: KubernetesSettings
         }, {
           icon: 'mdi-information-outline',
           name: 'Infos',
-          has_access: true,
+          has_access: this.user_state === this.ACCESS_APPROVED,
           component: Info
         }
       ]


### PR DESCRIPTION
The views now change depending on user state.
Since the endpoints for requesting cluster access are currently missing this branch will stay in draft.

Todo:
- get list of possible supervisiors to request
- implement logic of requesting access
- display different message corresponding to user state (new/ pending/ rejected)