### PR TITLE
serve instead of build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:lts-alpine
 
-# install simple http server for serving static content
-RUN npm install -g http-server
-
 # copy both 'package.json' and 'package-lock.json' (if available)
 COPY package*.json ./
 
@@ -15,10 +12,8 @@ COPY . .
 # set your env before the build process
 ENV VUE_APP_BASE_URL=https://portal.ris.beuth-hochschule.de
 
-# build app for production with minification
-RUN npm run build
-
 EXPOSE 8086
-CMD [ "http-server", "dist", "-a", "0.0.0.0", "-p", "8086" ]
+
+CMD [ "npm", "run", "serve"]
 
 


### PR DESCRIPTION
Instead of building the Vue App we run serve in order to prevent the routing issue.